### PR TITLE
fix: broken `getDb()` when called without an `alias`

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,11 @@ var MemoizedConnect = async.memoize(function (alias, callback) {
   MongoClient.connect.apply(MongoClient.connect, configs[alias].concat([callback]));
 });
 
-var getDb = module.exports = function(alias, callback) {
-  //directly using a connection string as alias.
-  var isMongoUrl = alias.indexOf('mongodb://') === 0 || alias.indexOf('mongodb+srv://') === 0
+var isMongoUrl = (str) => str.indexOf('mongodb://') === 0 || str.indexOf('mongodb+srv://') === 0;
 
-  if ( !(alias in configs) && typeof alias == 'string' && isMongoUrl ) {
+var getDb = module.exports = function(alias, callback) {
+  if ( !(alias in configs) && typeof alias == 'string' && isMongoUrl(alias) ) {
+    //directly using a connection string as alias.
     configs[alias] = [alias];
   }
 


### PR DESCRIPTION
This PR fixes an [issue](https://github.com/jfromaniello/mongo-getdb/pull/7/files#r341353255) present with the current latest version.

The `alias` argument of the `getDb()` method is an optional argument. The change from #7 is breaking some of our usages where we call `getDb()` with only a callback argument.
```
/var/lib/jenkins/workspace/myproject/node_modules/mongo-getdb/index.js:14
  var isMongoUrl = alias.indexOf('mongodb://') === 0 || alias.indexOf('mongodb+srv://') === 0
                         ^

TypeError: alias.indexOf is not a function
```

This PR fixes the issue by ensuring that `alias` is a string before evaluating if it is a mongo url.

Please publish this version as v4.1.2

cc @mpilar 