### PR TITLE
fix: Fix scoping for MongoClient.connect to handle changes in mongodb 4.11.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const MemoizedConnect = async.memoize(function (alias, callback) {
   if (!(alias in configs)) {
     throw new Error('unknown ' + alias + ' config');
   }
-  MongoClient.connect.apply(MongoClient.connect, configs[alias].concat([callback]));
+  MongoClient.connect.apply(MongoClient, configs[alias].concat([callback]));
 });
 
 const isMongoUrl = (str) => str.indexOf('mongodb://') === 0 || str.indexOf('mongodb+srv://') === 0;


### PR DESCRIPTION
Fixing a scoping issue introduced by this change in `mongodb@4.11.0`
Fix is backward compatible from before the change (see tests).

https://github.com/mongodb/node-mongodb-native/commit/8c63447f8bcfb6a71d1838444fd87d9c251106b0#diff-f005e84d9066ef889099ec2bd907abf7900f76da67603e4130e1c92fac92533dL583-R594

Testing:

Failing tests on `master` using mongodb@4.11.0 (fresh npm install)

![master-fail-4 11 0](https://user-images.githubusercontent.com/20172583/201751448-cbaa74b4-853c-4af1-9974-e4444e1c0b7b.png)

Passing tests on branch using mongodb@4.11.0 (fresh npm install)

![branch-pass-4 11 0](https://user-images.githubusercontent.com/20172583/201751517-f3035fa1-4e92-4045-83db-89d2e68d1678.png)

Passing tests on branch using mongodb@4.10.0

![branch-pass-4 10 0](https://user-images.githubusercontent.com/20172583/201751575-462324eb-8e2d-4c24-98ba-4b49291c55b5.png)


