### PR TITLE
feat: add support for mongodb@5.x and mongodb@6.x, drop mongodb@3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ An opinionated way to connect with the mongodb driver.
 
 Versions:
 
-| mongo-getdb  | mongodb |
-| ------------- | ------------- |
-| `mongo-getdb@^5`  | `mongodb@^4`  |
-| `mongo-getdb@^4`  | `mongodb@^3`  |
-| `mongo-getdb@^3`  | `mongodb@^2`  |
+| mongo-getdb      | mongodb                                      |
+|------------------|----------------------------------------------|
+| `mongo-getdb@^6` | `mongodb@^4` or `mongodb@^5` or `mongodb@^6` |
+| `mongo-getdb@^5` | `mongodb@^4`                                 |
+| `mongo-getdb@^4` | `mongodb@^3`                                 |
+| `mongo-getdb@^3` | `mongodb@^2`                                 |
 
 ## Installation
 

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 const MongoClient     = require("mongodb").MongoClient;
 const async           = require('async');
+const util            = require('util');
 const configs = {};
+const connectCb = util.callbackify(MongoClient.connect);
 
 const MemoizedConnect = async.memoize(function (alias, callback) {
   if (!(alias in configs)) {
     throw new Error('unknown ' + alias + ' config');
   }
-  MongoClient.connect.apply(MongoClient, configs[alias].concat([callback]));
+  connectCb.apply(MongoClient, configs[alias].concat([callback]));
 });
 
 const isMongoUrl = (str) => str.indexOf('mongodb://') === 0 || str.indexOf('mongodb+srv://') === 0;

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
   "devDependencies": {
     "chai": "^4.3.6",
     "mocha": "^10.0.0",
-    "mongodb-memory-server": "^8.5.2"
+    "mongodb-memory-server": "^10.1.2"
   },
   "peerDependencies": {
-    "mongodb": "^3.7.3 || ^4.5.0"
+    "mongodb": "^4.5.0 || ^5.9.2 || ^6.10.0"
   },
   "dependencies": {
     "async": "^3.2.3"


### PR DESCRIPTION
BREAKING CHANGE

Expands the `peerDependency` specification to match `mongodb@5.x` and `mongodb@6.x`, but also dropping support for `mongodb@3.x`.

Note that starting from `mongodb@5.X`, [the mongodb interface only supports promise-based APIs, they dropped support for callback-based APIs](https://github.com/mongodb/node-mongodb-native/blob/main/etc/notes/CHANGES_5.0.0.md#changes). I've added a `callbackify()` in a single place (`connect()`) in this PR to maintain functionality.